### PR TITLE
Remove label dependency and add internal metrics

### DIFF
--- a/TableDC/TableDC.py
+++ b/TableDC/TableDC.py
@@ -11,7 +11,7 @@ from torch.nn.parameter import Parameter
 from torch.optim import Adam
 from torch.nn import Linear
 from utils import load_data
-from evaluation import eva
+from evaluation import internal_metrics
 from tqdm import tqdm
 
 # set seed
@@ -112,7 +112,6 @@ def train_TableDC(dataset):
 
     # cluster parameter initiate
     data = torch.Tensor(dataset.x).to(device)
-    y = dataset.y
     with torch.no_grad():
         _, z = model.ae(data)
     
@@ -135,9 +134,9 @@ def train_TableDC(dataset):
             _, tmp_q, pred, _ = model(data)
             tmp_q = tmp_q.data
             p = target_distribution(tmp_q)     
-            res2 = pred.data.cpu().numpy().argmax(1)   
-            if epoch == 199:  
-                eva(y, res2, str(epoch))
+            res2 = pred.data.cpu().numpy().argmax(1)
+            if epoch == 199:
+                internal_metrics(dataset.x, res2)
     
         x_bar, q, pred, _ = model(data)
         
@@ -181,4 +180,4 @@ if __name__ == "__main__":
     start = time()
     train_TableDC(dataset)
     end = time()
-    print("Training took ",{end-start}," sec to run.")
+    print('Training took ', end - start, ' sec to run.')

--- a/TableDC/evaluation.py
+++ b/TableDC/evaluation.py
@@ -6,6 +6,7 @@ from sklearn.cluster import DBSCAN
 from sklearn.metrics.cluster import rand_score
 from sklearn.metrics.cluster import adjusted_rand_score
 from sklearn.metrics.cluster import normalized_mutual_info_score
+from sklearn.metrics import silhouette_score, davies_bouldin_score, calinski_harabasz_score
 import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
@@ -202,5 +203,15 @@ def eva(y_true, y_pred, epoch=0):
     print('epoch = '+ str(epoch) + ' Number of unary clusters = ' + str(unary_clusters))
     print('epoch = '+ str(epoch) + ' Median cluster count = ' + str(statistics.median(count)))
     print('epoch = '+ str(epoch) + ' Mean cluster count = ' + str(statistics.mean(count)))
-    
+
+def internal_metrics(X, y_pred):
+    X = np.array(X)
+    y_pred = np.array(y_pred)
+    if len(np.unique(y_pred)) > 1:
+        sil = silhouette_score(X, y_pred)
+    else:
+        sil = -1
+    db = davies_bouldin_score(X, y_pred)
+    ch = calinski_harabasz_score(X, y_pred)
+    print(f'Silhouette Score: {sil:.4f}, Davies-Bouldin Index: {db:.4f}, Calinski-Harabasz Index: {ch:.4f}')
 

--- a/TableDC/utils.py
+++ b/TableDC/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 
 import torch
 from torch.utils.data import Dataset
@@ -7,16 +8,21 @@ from torch.utils.data import Dataset
 
 class load_data(Dataset):
     def __init__(self, dataset):
-
         self.x = np.loadtxt('data/{}.txt'.format(dataset), dtype=float)
-        self.y = np.loadtxt('data/label.txt'.format(dataset), dtype=int)
+        label_path = 'data/label.txt'
+        if os.path.exists(label_path):
+            self.y = np.loadtxt(label_path, dtype=int)
+        else:
+            self.y = None
         
     def __len__(self):
         return self.x.shape[0]
 
     def __getitem__(self, idx):
-        return torch.from_numpy(np.array(self.x[idx])),\
-               torch.from_numpy(np.array(self.y[idx])),\
-               torch.from_numpy(np.array(idx))
+        sample = torch.from_numpy(np.array(self.x[idx]))
+        if self.y is not None:
+            return sample, torch.from_numpy(np.array(self.y[idx])), torch.from_numpy(np.array(idx))
+        else:
+            return sample, torch.tensor(-1), torch.from_numpy(np.array(idx))
 
 

--- a/entity resolution/ER.py
+++ b/entity resolution/ER.py
@@ -18,8 +18,7 @@ DIRECTORY_OUTPUT = 'embdi_master/pipeline/datasets/'
 # >>>>>>>>>>>>>>>>>>>>> 1.2 Preprocessing : remove ',' into text from columns
 
 if dataset_name == 'music_brainz_20k':
-    header_lab = ['CID'] # labels
-    header_lines = ['title', 'length', 'artist', 'album', 'year', 'language'] # datas
+    header_lines = ['title', 'length', 'artist', 'album', 'year', 'language']  # data columns
 
 
 d_save = DIRECTORY_OUTPUT
@@ -31,18 +30,11 @@ for f in os.listdir(DIRECTORY_OUTPUT):
 
 # Proceeding to save preprocess files    
 for filename in os.listdir(DIRECTORY_INPUT):
-    l_save = filename.split('.csv')[0] + '_labels.csv'
-
     df = pd.read_csv(DIRECTORY_INPUT + filename, sep=',')
-    
-    datas_lab = []
+
     datas_lines = []
 
     for i in range(len(df)):
-        # Proceed labels
-        d = []
-        d.append(df[header_lab[0]][i]) ; datas_lab.append(d)
-    
         # Proceed lines
         d = []
         for col in header_lines:
@@ -50,12 +42,6 @@ for filename in os.listdir(DIRECTORY_INPUT):
         datas_lines.append(d)
 
     
-    # Save labels as csv file
-    with open(l_save, 'w', encoding='UTF8', newline='') as f:
-        writer = csv.writer(f)
-        writer.writerow(header_lab)  # write the header
-        writer.writerows(datas_lab)  # write multiple rows
-
     # Save lines as csv file
     with open(d_save + filename, 'w', encoding='UTF8', newline='') as f:
         writer = csv.writer(f)
@@ -226,7 +212,6 @@ DIRECTORY_EMB = 'pipeline/embeddings/'
 
 vectors = []
 Text = []
-labels = []
 
 for filename in os.listdir(DIRECTORY_EMB): 
     if '.emb' in str(filename):
@@ -237,17 +222,7 @@ for filename in os.listdir(DIRECTORY_EMB):
                     # Get index of line int the raw dataset
                     index_line = int(line.split(' ')[0].split('__')[1])
                     
-                    # Add label
-                    df_lab = pd.read_csv(filename.split('.emb')[0] + '_labels.csv', sep=',')
-                    
-                    if dataset_name == 'music_brainz_20k':
-                        col_lab = 'CID'
-                    if dataset_name == 'north_carolina_voters_5m':
-                        col_lab = 'recid'
-                    
-                    labels.append(int(df_lab[col_lab][index_line]))
-                
-                    #print(len(set(labels)))
+
                                     
                     # Add vector
                     vectors.append(np.array([float(x) for x in line.split(' ')[1:]]))
@@ -259,75 +234,14 @@ for filename in os.listdir(DIRECTORY_EMB):
                         Text.append(lines_txt[index_line + 1]) 
 
 print('Number of records/entities: ' + str(len(vectors)))
-print('Number of labels: ' + str(len(set(labels))))
 
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>> 8. Deep clustering 
 
-number_instance = len(vectors) #(vectors)
+number_instance = len(vectors)
 vectors = vectors[:number_instance]
 Text = Text[:number_instance]
-labels = labels[:number_instance]
 # Transform list to array
 vectors = np.array(vectors)
-vectors1=pd.DataFrame(vectors) 
-labels=pd.DataFrame(labels) 
+vectors1=pd.DataFrame(vectors)
 vectors1.to_csv('X.txt', index=False, header = False,sep=' ')
-labels.to_csv('labels.txt', index=False, header = False,sep=' ')
-
-
-#-------------- Getting row vectors for geographicalSettelments-----------------
-
-
-# vectors = []
-# Text = []
-# labels = []
-
-# for filename in os.listdir(DIRECTORY_EMB): 
-#     if '.emb' in str(filename):
-#         with open(DIRECTORY_EMB + filename, 'r', encoding='utf-8') as fp: 
-#             lines = fp.readlines()
-#             for line in lines:
-#                 if line[:5] == 'idx__' :
-#                     # Get index of line int the raw dataset
-#                     index_line = int(line.split(' ')[0].split('__')[1])
-                    
-#                     # Add label
-#                     df_lab = pd.read_csv(filename.split('.emb')[0] + '_labels.csv', sep=',')
-                    
-#                     if dataset_name == 'geographicalSettelments':
-#                         col_lab = 'label'
-                    
-#                     labels.append(int(df_lab[col_lab][index_line]))
-                
-#                     #print(len(set(labels)))
-                                    
-#                     # Add vector
-#                     vectors.append(np.array([float(x) for x in line.split(' ')[1:]]))
-                
-#                     # Add text
-#                     with open(DIRECTORY_DATASET + filename.split('.emb')[0] + '.csv', 'r', encoding='utf-8') as ftt:
-#                         lines_txt = ftt.readlines()
-#                         # +1: because we remove header line
-#                         Text.append(lines_txt[index_line + 1]) 
-
-# print('Number of records/entities: ' + str(len(vectors)))
-# print('Number of labels: ' + str(len(set(labels))))
-
-# number_instance = len(vectors) #(vectors)
-# vectors = vectors[:number_instance]
-# Text = Text[:number_instance]
-# labels = labels[:number_instance]
-
-# # Transform list to array
-# vectors = np.array(vectors)
-# y = labels
-
-# vectors1=pd.DataFrame(vectors) 
-# y1=pd.DataFrame(y) 
-# vectors1.to_csv('X.txt', index=False, header = False,sep=' ')
-# y1.to_csv('labels.txt', index=False, header = False,sep=' ')
-
-
-
-        


### PR DESCRIPTION
## Summary
- strip label generation from entity resolution preprocessing
- allow utils loader to work without labels
- evaluate TableDC using Silhouette, Davies–Bouldin and Calinski–Harabasz scores
- clean up TableDC training script output

## Testing
- `python -m py_compile TableDC/TableDC.py TableDC/utils.py TableDC/evaluation.py 'entity resolution/ER.py'`

------
https://chatgpt.com/codex/tasks/task_e_6858a6f229588325b926c198e83b628e